### PR TITLE
Add replyTo field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ An action that simply sends a mail to multiple recipients.
     cc: kyloren@example.com,leia@example.com
     # Optional blind carbon copy recipients
     bcc: r2d2@example.com,hansolo@example.com
+    # Optional recipient of the email response
+    replyTo: luke@skywalter.com
     # Optional unsigned/invalid certificates allowance:
     ignore_cert: true
     # Optional content type (defaults to text/plain):

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An action that simply sends a mail to multiple recipients.
     # Optional blind carbon copy recipients
     bcc: r2d2@example.com,hansolo@example.com
     # Optional recipient of the email response
-    replyTo: luke@skywalter.com
+    reply_to: luke@example.com
     # Optional unsigned/invalid certificates allowance:
     ignore_cert: true
     # Optional content type (defaults to text/plain):

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   bcc:
     description: Blind carbon copy recipients (separated with comma)
     required: false
+  reply_to:
+    description: An email address that will appear on the Reply-To field
+    required: false
   ignore_cert:
     description: Allow unsigned/invalid certificates
     required: false

--- a/main.js
+++ b/main.js
@@ -41,6 +41,7 @@ async function main() {
         const to = core.getInput("to", { required: true })
         const cc = core.getInput("cc", { required: false })
         const bcc = core.getInput("bcc", { required: false })
+        const replyTo = core.getInput("reply_to", { required: false })
         const contentType = core.getInput("content_type", { required: true })
         const attachments = core.getInput("attachments", { required: false })
         const convertMarkdown = core.getInput("convert_markdown", { required: false })
@@ -64,6 +65,7 @@ async function main() {
             to: to,
             cc: cc ? cc : undefined,
             bcc: bcc ? bcc : undefined,
+            replyTo: replyTo ? replyTo : undefined,
             subject: subject,
             text: contentType != "text/html" ? getBody(body, convertMarkdown) : undefined,
             html: contentType == "text/html" ? getBody(body, convertMarkdown) : undefined,


### PR DESCRIPTION
This PR adds supports for `replyTo` field. 

Use case:
After an email from the GitHub workflow is sent we might want the other part to reply to that email not necessarily to the sender email. For that purpose we use `replyTo` field.

@dawidd6 could you please have a look?