### PR TITLE
Adding CID tags for attachments

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ function getFrom(from, username) {
 async function getAttachments(attachments) {
     const globber = await glob.create(attachments.split(',').join('\n'))
     const files = await globber.glob()
-    return files.map(f => ({ path: f }))
+    return files.map(f => ({ path: f, cid: f}))
 }
 
 async function main() {

--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ function getFrom(from, username) {
 async function getAttachments(attachments) {
     const globber = await glob.create(attachments.split(',').join('\n'))
     const files = await globber.glob()
-    return files.map(f => ({ path: f, cid: f}))
+    return files.map(f => ({ path: f, cid: f.replace(/^.*[\\\/]/, '')}))
 }
 
 async function main() {


### PR DESCRIPTION
Hi there,

This took me a while to figure out but basically with this tiny modification, any attachment (images primarily) can be used as inline images within the HTML email like:

```{html}
<img src="cid:name_of_image_file.jpg">
```

This will only work if the image files are in the root directory (as I'm parsing out all parent folders from the path) but in that case it works like a charm, and  even Gmail likes it and displays the image automatically within the body of the email at the designated location as opposed to just having the image be at bottom like some random attachment.. 

I thought this is quite a big improvement.. 