### PR TITLE
Fix #176 by removing useless warning message

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,10 +96,6 @@ async function main() {
             throw new Error("Server address must be specified")
         }
 
-        if (!username || !password) {
-            core.warning("Username and password not specified. You should only do this if you are using a self-hosted runner to access an on-premise mail server.")
-        }
-
         const transport = nodemailer.createTransport({
             host: serverAddress,
             auth: username && password ? {


### PR DESCRIPTION
Remove the warning message when username / password aren't provided for smtp server.