### PR TITLE
Update to Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,5 +64,5 @@ inputs:
     description: Debug option for nodemailer
     required: false
 runs:
-  using: node16
+  using: node20
   main: main.js


### PR DESCRIPTION
GitHub is now deprecating Node 16, update this to hide warnings.  Tested successfully with these parameters:
connection_url:
subject: 
to: 
from: 
reply_to: 
cc: 
body:
html_body:
convert_markdown: true
secure: true
priority: normal