### PR TITLE
Enable the Showdown option to support tables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,5 +64,5 @@ inputs:
     description: Debug option for nodemailer
     required: false
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function getText(textOrFile, convertMarkdown) {
 
     // Convert Markdown to HTML
     if (convertMarkdown) {
-        const converter = new showdown.Converter()
+        const converter = new showdown.Converter({tables: true})
         text = converter.makeHtml(text)
     }
 


### PR DESCRIPTION
action-send-email uses Showdown to render Markdown into HTML.  By default Showdown disables the rendering of tables.  I suggest enabling this by default.