### PR TITLE
fix: Use extended HELLO with github.com domain

### DIFF
--- a/main.js
+++ b/main.js
@@ -170,6 +170,7 @@ async function main() {
 
         const transport = nodemailer.createTransport({
             host: serverAddress,
+            name: "github.com",
             auth:
                 username && password
                     ? {


### PR DESCRIPTION
For years I had the issue with this action that GMail terminated the connection with this error:

```
response=421-4.7.0 Try again later, closing connection. (EHLO)
```

After many retries it usually succeeded, but sometimes it kept on failing even after 20 retries.

I always thought it was due to some rate-limiting, but last year I discovered that the reason for this error is that the action does not set the `HELLO` line for the SMTP protocol, and GMail does not like that.

With this fix I never saw the `421` error again, and I have been testing it for a long time. So it never was related to any form of rate-limiting at all.

It simply adds: `HELLO github.com` and now my mail never gets rejected anymore.

Fixes: #196 
