### PR TITLE
Take the proxy from `smtp_proxy` instead of `HTTP_PROXY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Some features:
 - name: Send mail
   uses: dawidd6/action-send-mail@<REF>
   env:
-    # Optional http proxy:
-    HTTP_PROXY: http://proxy.example.test:3128
+    # Optional proxy, NO_PROXY is honored too:
+    SMTP_PROXY: http://proxy.example.test:3128
   with:
     # Specify connection via URL (replaces server_address, server_port, secure,
     # username and password)

--- a/main.js
+++ b/main.js
@@ -6,13 +6,15 @@ import fs from "node:fs";
 import showdown from "showdown";
 import path from "node:path";
 
-// SMTP_PROXY, exempted by NO_PROXY.
+// smtp_proxy or smtps_proxy, exempted by no_proxy, each preferred lowercase like curl.
 function getProxy(host) {
-    const proxy = process.env.SMTP_PROXY || process.env.smtp_proxy;
+    const env = (name) => process.env[name] || process.env[name.toUpperCase()];
+
+    const proxy = env("smtp_proxy") || env("smtps_proxy");
     if (!proxy) return undefined;
 
     host = `.${host.toLowerCase()}`;
-    const excluded = (process.env.NO_PROXY || process.env.no_proxy || "")
+    const excluded = (env("no_proxy") || "")
         .split(",")
         .map((entry) => entry.trim().replace(/^\./, "").toLowerCase())
         .some((entry) => entry && (entry === "*" || host.endsWith(`.${entry}`)));

--- a/main.js
+++ b/main.js
@@ -6,6 +6,20 @@ import fs from "node:fs";
 import showdown from "showdown";
 import path from "node:path";
 
+// SMTP_PROXY, exempted by NO_PROXY.
+function getProxy(host) {
+    const proxy = process.env.SMTP_PROXY || process.env.smtp_proxy;
+    if (!proxy) return undefined;
+
+    host = `.${host.toLowerCase()}`;
+    const excluded = (process.env.NO_PROXY || process.env.no_proxy || "")
+        .split(",")
+        .map((entry) => entry.trim().replace(/^\./, "").toLowerCase())
+        .some((entry) => entry && (entry === "*" || host.endsWith(`.${entry}`)));
+
+    return excluded ? undefined : proxy;
+}
+
 function getText(textOrFile, convertMarkdown) {
     let text = textOrFile;
 
@@ -188,7 +202,7 @@ async function main() {
                     : undefined,
             logger: nodemailerdebug == "true" ? true : nodemailerlog,
             debug: nodemailerdebug,
-            proxy: process.env.HTTP_PROXY,
+            proxy: getProxy(serverAddress),
         });
 
         const messageOptions = {


### PR DESCRIPTION
`HTTP_PROXY` is not meant to be used for SMTP proxies. This adds curl-compatible environment name lookup for `smtp_proxy`, `SMTP_PROXY`, `smtps_proxy`, `SMTPS_PROXY`.

This is a breaking change for users who previously relied on the wrong `HTTP_PROXY` variable which could have only worked if the same proxy hosted both HTTP and SMTP services.

For more detail about the env var resolution order also see https://about.gitlab.com/blog/we-need-to-talk-no-proxy/.