### PR TITLE
Add require_tls input to prevent STARTTLS fallback to plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Some features:
     # Optional whether this connection use TLS (default is true if server_port is 465)
     secure: true
 
+    # Optional: when secure is false (e.g. STARTTLS on port 587), abort the
+    # connection if the server does not support/negotiate STARTTLS, instead
+    # of silently falling back to a plain text connection. Recommended
+    # whenever secure is false and you authenticate with username/password.
+    require_tls: true
+
     # Optional (recommended) mail server username:
     username: ${{secrets.MAIL_USERNAME}}
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
     default: "25"
   secure:
     description: Whether this connection use TLS (default is true if server_port is 465)
+  require_tls:
+    description: When 'secure' is false, refuse to send if the server does not support STARTTLS (prevents credentials from ever being sent in clear text)
+    required: false
   username:
     description: Authenticate as this user to SMTP server
   password:

--- a/main.js
+++ b/main.js
@@ -94,6 +94,7 @@ async function main() {
         let serverAddress = core.getInput("server_address");
         let serverPort = core.getInput("server_port");
         let secure = core.getInput("secure");
+        const requireTLS = core.getInput("require_tls", { required: false });
         let username = core.getInput("username");
         let password = core.getInput("password");
 
@@ -196,6 +197,7 @@ async function main() {
                     : undefined,
             port: serverPort,
             secure: secure === "true",
+            requireTLS: requireTLS === "true",
             tls:
                 ignoreCert == "true"
                     ? {


### PR DESCRIPTION
Expose nodemailer's requireTLS option so that when secure is false (e.g. STARTTLS on port 587), the connection aborts if the server does not support/negotiate STARTTLS, instead of silently sending credentials in clear text.

This should also fix #215 (at least things commented there, like https://github.com/dawidd6/action-send-mail/issues/215#issuecomment-2380614415)